### PR TITLE
Updates to support the storage of the generation of the Pixalytics TrainingDML-AI implementation

### DIFF
--- a/pytdml/type/extended_types.py
+++ b/pytdml/type/extended_types.py
@@ -35,7 +35,7 @@ import geojson
 from geojson import Feature
 from pytdml.type.basic_types import Label, TrainingData, TrainingDataset, DataQuality, Task, \
     MetricsInLiterature, \
-    KeyValuePair, Labeling, Changeset
+    KeyValuePair, Labeling, Changeset, Scope
 
 
 @dataclass
@@ -71,6 +71,7 @@ class ObjectLabel(Label):
     """
     Extended label type for object level training data
     """
+    type: str = "ObjectLabel"
     object: Feature = field(default=None)
     label_class: str = field(default=None)
     bbox_type: str = field(default=None)
@@ -115,6 +116,7 @@ class PixelLabel(Label):
     """
     Extended label type for pixel level training data
     """
+    type: str = "PixelLabel"
     image_url: Union[str, List[str]] = field(default=None)
     image_format: Union[str, List[str]] = field(default=None)
 
@@ -191,6 +193,7 @@ class EOTask(Task):
     """
     Extended task type for EO training data
     """
+    type: str = "EOTask"
     task_type: str = field(default=None)
 
     def to_dict(self):
@@ -222,6 +225,7 @@ class EOTrainingData(TrainingData):
     """
     Extended training data type for EO training data
     """
+    type: str  = "EOTrainingData"
     extent: List[float] = field(default_factory=list)
     date_time: Union[str, List[str]] = field(default=None)
     data_url: Union[str, List[str]] = field(default=None)

--- a/pytdml/yaml_to_tdml.py
+++ b/pytdml/yaml_to_tdml.py
@@ -346,7 +346,7 @@ def traverse_s3(object_path, file_format):
         for root, dirs, files in s3.walk(bucket):
                 for f in files:
                     if (split[3] in root) and (split[4] in root) and (split[5] in root) and (file_format == os.path.splitext(f)[-1]):
-                        s3_object.append(os.path.join("s://"+root, f))
+                        s3_object.append(os.path.join("s3://"+root, f))
         return s3_object
     except IOError:
         return IOError("Failed to load dataset")

--- a/pytdml/yaml_to_tdml.py
+++ b/pytdml/yaml_to_tdml.py
@@ -77,6 +77,7 @@ def yaml_to_eo_tdml(yaml_path):
             providers=yaml_dict["providers"],
             keywords=yaml_dict["keywords"],
             classification_schema=yaml_dict['classification_schema'],
+            number_of_classes=yaml_dict['number_of_classes'],
             classes=yaml_dict['classes'],
             tasks=tasks,
             extent=yaml_dict['extent'],


### PR DESCRIPTION
In parallel, I've just pushed my documentation of the implementation to the 
[TrainingDML-AI_SWG](https://github.com/opengeospatial/TrainingDML-AI_SWG) repo. I needed to make these changes for my implementation to work. The changes include:
- support for the TrainingDML-AI file to be stored on an Amazon S3 bucket alongside the image and labelled data
- updates for the ingestion of this [yaml file](https://github.com/opengeospatial/T17-API-D168/blob/main/build_catalog/configuration-tds-pytdml-s3.yaml)

If I need clarification on the pytdml code and I need to do something different, please feel free to adjust/reject these proposed updates and provide feedback.