### PR TITLE
pydantic rewrite pytdml type according to TrainingDML-AI schemajson

### DIFF
--- a/pytdml/io/tdml_readers.py
+++ b/pytdml/io/tdml_readers.py
@@ -30,6 +30,8 @@
 # ------------------------------------------------------------------------------
 import json
 
+# from pytdml.type.basic_types_old import TrainingDataset
+# from pytdml.type.extended_types_old import EOTrainingDataset
 from pytdml.type.basic_types import TrainingDataset
 from pytdml.type.extended_types import EOTrainingDataset
 
@@ -41,9 +43,11 @@ def read_from_json(file_path: str):
     with open(file_path, "r", encoding='utf-8') as f:
         json_dict = json.load(f)
         # Different kinds of training datasets are supported
-        if json_dict["type"] == "TrainingDataset":
-            return TrainingDataset.from_dict(json_dict)
-        elif json_dict["type"] == "EOTrainingDataset":
-            return EOTrainingDataset.from_dict(json_dict)
+        if json_dict["type"] == "AI_TrainingDataset":
+            return TrainingDataset(**json_dict)
+            # return TrainingDataset.from_dict(json_dict)
+        elif json_dict["type"] == "AI_EOTrainingDataset":
+            return EOTrainingDataset(**json_dict)
+            # return EOTrainingDataset.from_dict(json_dict)
         else:
             raise ValueError("Unknown TDML type: {}".format(json_dict["type"]))

--- a/pytdml/io/tdml_writers.py
+++ b/pytdml/io/tdml_writers.py
@@ -1,8 +1,9 @@
 # ------------------------------------------------------------------------------
 #
 # Project: pytdml
-# Authors: Boyi Shangguan, Kaixuan Wang
+# Authors: Boyi Shangguan, Kaixuan Wang, Zhaoyan Wu
 # Created: 2022-05-04
+# Modified: 2023-10-27
 # Email: sgby@whu.edu.cn
 #
 # ------------------------------------------------------------------------------
@@ -39,4 +40,5 @@ def write_to_json(td: TrainingDataset, file_path: str, indent: Union[None, int, 
     Writes a TrainingDataset to a JSON file.
     """
     with open(file_path, "w", encoding='utf-8') as f:
-        json.dump(remove_empty(td.to_dict()), f, indent=indent, ensure_ascii=False)
+        json.dump(td.dict(by_alias=True,exclude_none=True), f, indent=indent, ensure_ascii=False)
+        # json.dump(remove_empty(td.dict()), f, indent=indent, ensure_ascii=False)

--- a/pytdml/type/_utils.py
+++ b/pytdml/type/_utils.py
@@ -1,9 +1,8 @@
 # ------------------------------------------------------------------------------
 #
 # Project: pytdml
-# Authors: Boyi Shangguan, Kaixuan Wang, Zaoyan Wu
-# Created: 2022-05-04
-# Modified: 2023-10-27
+# Authors: Boyi Shangguan, Kaixuan Wang, Zhaoyan Wu
+# Created: 2023-10-27
 # Email: sgby@whu.edu.cn
 #
 # ------------------------------------------------------------------------------
@@ -29,33 +28,60 @@
 # SOFTWARE.
 #
 # ------------------------------------------------------------------------------
-from .basic_types import BaseCamelModel
-from .basic_types import KeyValuePair
-from .basic_types import MD_ScopeDescription
-from .basic_types import MD_Band
-from .basic_types import MD_Scope
-from .basic_types import CIDate
-from .basic_types import MD_BrowseGraphic
-from .basic_types import CICitation
-from .basic_types import MD_Identifier
-from .basic_types import MetricsPair
-from .basic_types import MetricsInLiterature
-from .basic_types import Task
-from .basic_types import Labeler
-from .basic_types import LabelingProcedure
-from .basic_types import Labeling
-from .basic_types import QualityElement
-from .basic_types import DataQuality
-from .basic_types import Label
-from .basic_types import TrainingData
-from .basic_types import Changeset
-from .basic_types import StatisticsInfo
-from .basic_types import TrainingDataset
 
 
-from .extended_types import EOTrainingDataset
-from .extended_types import EOTrainingData
-from .extended_types import SceneLabel
-from .extended_types import ObjectLabel
-from .extended_types import PixelLabel
-from .extended_types import EOTask
+from datetime import datetime
+import re
+
+
+class InvalidDatetimeError(ValueError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+def _validate_date(v: str) -> str:
+    """validate date string and return datetime object
+
+    Args:
+        v (str): date string
+
+    Raises:
+        ValidationError: date string does not match any allowed format
+
+    Returns:
+        str: valid date string
+    """
+    formats = [
+        "%Y-%m-%dT%H:%M:%S",  # date-time
+        "%Y-%m-%d",  # date
+        "%H:%M:%S",  # time
+    ]
+    year_pattern = "^(19|20)\\d{2}$"
+    year_month_pattern = "^(19|20)\\d{2}-(0[1-9]|1[0-2])$"
+
+    # Try to match date-time, date, or time format
+    for fmt in formats:
+        try:
+            datetime.strptime(v, fmt)
+            return v
+        except ValueError:
+            pass
+
+    # Try to match year or year-month pattern
+    if re.match(year_pattern, v) or re.match(year_month_pattern, v):
+        return v
+
+    raise InvalidDatetimeError(f"String {v} does not match any allowed format")
+
+
+def to_camel(string: str) -> str:
+    """Change snake_case to camelCase
+
+    Args:
+        string (str): snake_case string
+
+    Returns:
+        str: camelCase string
+    """
+    return re.sub(r"_(\w)", lambda match: match.group(1).upper(), string)

--- a/pytdml/type/basic_types.py
+++ b/pytdml/type/basic_types.py
@@ -1,8 +1,9 @@
 # ------------------------------------------------------------------------------
 #
 # Project: pytdml
-# Authors: Boyi Shangguan, Kaixuan Wang
+# Authors: Boyi Shangguan, Kaixuan Wang, Zhaoyan Wu
 # Created: 2022-05-04
+# Modified: 2023-10-27
 # Email: sgby@whu.edu.cn
 #
 # ------------------------------------------------------------------------------
@@ -28,566 +29,317 @@
 # SOFTWARE.
 #
 # ------------------------------------------------------------------------------
-from dataclasses import dataclass, field
-from typing import List, Union
+
+from typing import List, Union, Optional, Dict, Literal
+from pydantic import BaseModel, Field, validator, root_validator
+from datetime import datetime
+from pytdml.type._utils import _validate_date, to_camel
 
 
-@dataclass
-class KeyValuePair:
+class BaseCamelModel(BaseModel):
+    """
+    Basic model with camel case alias
+    Since python use snake case as default
+    We need to convert it to camel case for JSON
+    """
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+
+    def json(self, **kwargs):
+        return super().json(by_alias=True, **kwargs)
+
+
+class KeyValuePair(BaseCamelModel):
     """
     Key/Value pair type
     """
+
     key: str
     value: Union[str, int, float, bool, None]
 
-    def to_dict(self):
-        return {self.key: self.value}
 
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if len(json_dict.keys()) == 1:
-            for key in json_dict.keys():
-                return KeyValuePair(key, json_dict[key])
-        else:
-            raise ValueError("The given json_dict is not a valid KeyValuePair")
-
-
-@dataclass
-class MetricsInLiterature:
-    """
-    Metrics in literature type
-    """
-    doi: str
-    algorithm: str = field(default=None)
-    metrics: List[KeyValuePair] = field(default_factory=list)
-
-    def to_dict(self):
-        return {
-            "doi": self.doi,
-            "algorithm": self.algorithm,
-            "metrics": [m.to_dict() for m in self.metrics]
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("doi"):
-            metrics_in_literature = MetricsInLiterature(json_dict["doi"])
-            if json_dict.__contains__("algorithm"):
-                metrics_in_literature.algorithm = json_dict["algorithm"]
-            if json_dict.__contains__("metrics"):
-                metrics_in_literature.metrics = [KeyValuePair.from_dict(m) for m in json_dict["metrics"]]
-            return metrics_in_literature
-        else:
-            raise ValueError("The given json_dict is not a valid MetricsInLiterature")
-
-
-@dataclass
-class Task:
-    """
-    Basic task type
-    """
-    id: str
-    dataset_id: str = field(default=None)
-    description: str = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "Task",
-            "id": self.id,
-            "datasetId": self.dataset_id,
-            "description": self.description
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict["type"] == "Task":
-            task = Task(json_dict["id"])
-            if json_dict.__contains__("datasetId"):
-                task.dataset_id = json_dict["datasetId"]
-            if json_dict.__contains__("description"):
-                task.description = json_dict["description"]
-            return task
-        else:
-            raise ValueError("The given json_dict is not a valid Task")
-
-
-@dataclass
-class Labeler:
-    """
-    Labeler type
-    """
-    id: str
-    name: str = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "Labeler",
-            "id": self.id,
-            "name": self.name
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict["type"] == "Labeler":
-            labeler = Labeler(json_dict["id"])
-            if json_dict.__contains__("name"):
-                labeler.name = json_dict["name"]
-            return labeler
-        else:
-            raise ValueError("The given json_dict is not a valid Labeler")
-
-
-@dataclass
-class LabelingProcedure:
-    """
-    Labeling procedure type
-    """
-    id: str
-    methods: List[str] = field(default_factory=list)
-    tools: List[str] = field(default_factory=list)
-
-    def to_dict(self):
-        return {
-            "type": "LabelingProcedure",
-            "id": self.id,
-            "methods": self.methods,
-            "tools": self.tools
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict["type"] == "LabelingProcedure":
-            labeling_procedure = LabelingProcedure(json_dict["id"])
-            if json_dict.__contains__("methods"):
-                labeling_procedure.method = json_dict["methods"]
-            if json_dict.__contains__("tools"):
-                labeling_procedure.tool = json_dict["tools"]
-            return labeling_procedure
-        else:
-            raise ValueError("The given json_dict is not a valid LabelingProcedure")
-
-
-@dataclass
-class Labeling:
-    """
-    Labeling type
-    """
-    id: str
-    scope: object
-    labelers: List[Labeler] = field(default_factory=list)
-    procedure: LabelingProcedure = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "Labeling",
-            "id": self.id,
-            "scope": self.scope,
-            "labelers": [labeler.to_dict() for labeler in self.labelers],
-            "procedure": self.procedure.to_dict() if self.procedure is not None else None,
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict.__contains__("scope") and json_dict["type"] == "Labeling":
-            labeling = Labeling(json_dict["id"], json_dict["scope"])
-            if json_dict.__contains__("labelers"):
-                labeling.labelers = [Labeler.from_dict(labeler) for labeler in json_dict["labelers"]]
-            if json_dict.__contains__("procedure"):
-                labeling.procedure = LabelingProcedure.from_dict(json_dict["procedure"])
-            return labeling
-        else:
-            raise ValueError("The given json_dict is not a valid Labeling")
-
-
-@dataclass
-class ScopeDescription:
+class MD_ScopeDescription(BaseCamelModel):
     """
     From ISO 19115-1 MD_ScopeDescription
     """
-    attributes: List[str] = field(default_factory=list)
-    features: List[str] = field(default_factory=list)
-    featureInstances: List[str] = field(default_factory=list)
-    attributeInstances: List[str] = field(default_factory=list)
-    dataset: str = field(default=None)
-    other: str = field(default=None)
 
-    def to_dict(self):
-        return {
-            "attributes": self.attributes,
-            "features": self.features,
-            "featureInstances": self.featureInstances,
-            "attributeInstances": self.attributeInstances,
-            "dataset": self.dataset,
-            "other": self.other
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        sd = ScopeDescription()
-        if json_dict.__contains__("attributes"):
-            sd.attributes = json_dict["attributes"]
-        if json_dict.__contains__("features"):
-            sd.features = json_dict["features"]
-        if json_dict.__contains__("featureInstances"):
-            sd.featureInstances = json_dict["featureInstances"]
-        if json_dict.__contains__("attributeInstances"):
-            sd.attributeInstances = json_dict["attributeInstances"]
-        if json_dict.__contains__("dataset"):
-            sd.dataset = json_dict["dataset"]
-        if json_dict.__contains__("other"):
-            sd.other = json_dict["other"]
-        return sd
+    dataset: str
+    features: Optional[List[str]]
 
 
-@dataclass
-class Scope:
+class MD_Band(BaseCamelModel):
+    """
+    From ISO 19115-1 MD_Band
+    """
+    bound_max: Optional[float]
+    bound_min: Optional[float]
+    bound_units: Optional[Literal["nm", "um", "cm", "dm", "m", "km"]]
+    peak_response: Optional[float]
+    tone_gradation: Optional[int]
+
+    @root_validator(pre=True)
+    def check_dependent_required(cls, v):
+        bound_units = v.get("boundUnits")
+        bound_max = v.get("boundMax")
+        bound_min = v.get("boundMin")
+
+        # check dependRequired in jsonschema
+        if bound_units is not None and (bound_max is None or bound_min is None):
+            raise ValueError(
+                "boundMax and boundMin are required when boundUnits is present"
+            )
+
+        return v
+
+
+class MD_Scope(BaseCamelModel):
     """
     From ISO 19115-1 MD_Scope
     """
+
     level: str
-    levelDescription: List[ScopeDescription] = field(default_factory=list)
-
-    def to_dict(self):
-        return {
-            "level": self.level,
-            "levelDescription": [ld.to_dict for ld in self.levelDescription]
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("level"):
-            scope = Scope(json_dict["level"])
-            if json_dict.__contains__("levelDescription"):
-                scope.levelDescription = [ScopeDescription.from_dict(ld) for ld in json_dict["levelDescription"]]
-            return scope
-        else:
-            raise ValueError("The given json_dict is not a valid Scope")
+    extent: Optional[List[float]] = Field(min_items=4)
+    level_description: Optional[MD_ScopeDescription]
 
 
-@dataclass
-class QualityElement:
+class CIDate(BaseCamelModel):
+    """
+    From ISO 19115-1 CI_Date
+    """
+
+    date: str
+    dateType: str
+
+    @validator("date")
+    def validate_date(cls, v):
+        return _validate_date(v)
+
+
+class MD_BrowseGraphic(BaseCamelModel):
+    """From ISO 19115-1 MD_BrowseGraphic"""
+
+    file_name: str
+    file_description: Optional[str]
+    file_type: Optional[str]
+
+
+class CICitation(BaseCamelModel):
+    """
+    From ISO 19115-1 CI_Citation
+    """
+
+    title: str
+    alternateTitle: Optional[List[str]]
+    date: Optional[CIDate]
+    edition: Optional[str]
+    edition_date: Optional[str]
+    graphic: Optional[List[MD_BrowseGraphic]]
+    identifier: Optional[List[KeyValuePair]]
+    ISBN: Optional[str]
+    ISSN: Optional[str]
+
+    @validator("edition_date")
+    def validate_edition_date(cls, v):
+        return _validate_date(v)
+
+
+class MD_Identifier(BaseCamelModel):
+    """
+    From ISO 19115-1 MD_Identifier
+    """
+
+    code: str
+    authority: Optional[CICitation]
+    code_space: Optional[str]
+    version: Optional[str]
+    description: Optional[str]
+
+
+class MetricsPair(BaseCamelModel):
+    """
+    Metrics pair type
+    """
+
+    name: str
+    value: float
+
+
+class MetricsInLiterature(BaseCamelModel):
+    """
+    Metrics in literature type
+    """
+
+    doi: str
+    algorithm: str = None
+    metrics: Optional[List[MetricsPair]] = Field(min_items=1)
+
+
+class Task(BaseCamelModel):
+    """
+    Basic task type
+    """
+
+    id: str
+    dataset_id: Optional[str]
+    description: Optional[str]
+
+
+class Labeler(BaseCamelModel):
+    """
+    Labeler type
+    """
+
+    id: str
+    name: str
+    type: Literal["AI_Labeler"]
+
+
+class LabelingProcedure(BaseCamelModel):
+    """
+    Labeling procedure type
+    """
+
+    type: Literal["AI_LabelingProcedure"]
+    id: str
+    methods: List[str] = []
+    tools: Optional[List[str]]
+
+
+class Labeling(BaseCamelModel):
+    """
+    Labeling type
+    """
+
+    id: str
+    scope: MD_Scope
+    type: Literal["AI_Labeling"]
+    labelers: Optional[List[Labeler]]
+    procedure: Optional[LabelingProcedure]
+
+
+class QualityElement(BaseCamelModel):
     """
     From ISO 19157-1 QualityElement
     """
-    type: str = field(default=None)
-    measure: str = field(default=None)
-    evaluation_method: str = field(default=None)
-    result: str = field(default=None)
 
-    def to_dict(self):
-        return {
-            "type": self.type,
-            "measure": self.measure,
-            "evaluationMethod": self.evaluation_method,
-            "result": self.result
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        quality_element = QualityElement()
-        if json_dict.__contains__("type"):
-            quality_element.type = json_dict["type"]
-        if json_dict.__contains__("measure"):
-            quality_element.measure = json_dict["measure"]
-        if json_dict.__contains__("evaluationMethod"):
-            quality_element.evaluation_method = json_dict["evaluationMethod"]
-        if json_dict.__contains__("result"):
-            quality_element.result = json_dict["resule"]
-        return quality_element
+    type: str
+    measure: str
+    evaluation_method: str
+    result: List[str]
 
 
-@dataclass
-class DataQuality:
+class DataQuality(BaseCamelModel):
     """
     From ISO 19157-1 DataQuality
     """
-    scope: Scope
-    report: List[QualityElement] = field(default_factory=list)
 
-    def to_dict(self):
-        return {
-            "scope": self.scope.to_dict() if self.scope is not None else None,
-            "report": [r.to_dict() for r in self.report],
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("scope"):
-            data_quality = DataQuality(scope=Scope.from_dict(json_dict["scope"]))
-            if json_dict.__contains__("report"):
-                data_quality.report = [QualityElement.from_dict(element) for element in json_dict["report"]]
-            return data_quality
-        else:
-            raise ValueError("The given json_dict is not a valid DataQuality")
+    type: Literal["DataQuality"]
+    scope: MD_Scope
+    report: Optional[List[QualityElement]]
 
 
-@dataclass
-class Label:
+class Label(BaseCamelModel):
     """
     Basic label type
     """
-    is_negative: bool = field(default=None)
-    confidence: float = field(default=None)
 
-    def to_dict(self):
-        return {
-            "type": "Label",
-            "isNegative": self.is_negative,
-            "confidence": self.confidence
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict["type"] == "Label":
-            label = Label()
-            if json_dict.__contains__("isNegative"):
-                label.is_negative = json_dict["isNegative"]
-            if json_dict.__contains__("confidence"):
-                label.confidence = json_dict["confidence"]
-            return label
-        else:
-            raise ValueError("The given json_dict is not a valid Label")
+    is_negative: Optional[bool]  # Optional without default value
+    confidence: Optional[float] = Field(
+        ge=0.0, le=1.0
+    )  # Optional without default value
 
 
-@dataclass
-class TrainingData:
+class TrainingData(BaseCamelModel):
     """
     Basic training data type
     """
+
     id: str
-    dataset_id: str = field(default=None)
-    training_type: str = field(default=None)
-    number_of_labels: int = field(default=None)
-    data_sources: List[str] = field(default_factory=list)
-    quality: DataQuality = field(default=None)
-    labeling: List[Labeling] = field(default_factory=list)
-    labels: List[Label] = field(default_factory=list)
-
-    def get_labels(self) -> List[Label]:
-        """
-        Returns the labels of the training data
-        """
-        return self.labels
-
-    def to_dict(self):
-        return {
-            "type": "TrainingData",
-            "id": self.id,
-            "trainingType": self.training_type,
-            "numberOfLabels": self.number_of_labels,
-            "dataSources": self.data_sources,
-            "quality": self.quality.to_dict() if self.quality is not None else None,
-            "labeling": [ll.to_dict() for ll in self.labeling],
-            "labels": [label.to_dict() for label in self.labels]
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict["type"] == "TrainingData":
-            training_data = TrainingData(json_dict["id"])
-            if json_dict.__contains__("trainingType"):
-                training_data.training_type = json_dict["trainingType"]
-            if json_dict.__contains__("numberOfLabels"):
-                training_data.number_of_labels = json_dict["numberOfLabels"]
-            if json_dict.__contains__("dataSources"):
-                training_data.data_sources = json_dict["dataSources"]
-            if json_dict.__contains__("quality"):
-                training_data.quality = DataQuality.from_dict(json_dict["quality"])
-            if json_dict.__contains__("labeling"):
-                training_data.labeling = [Labeling.from_dict(ll) for ll in json_dict["labeling"]]
-            if json_dict.__contains__("labels"):
-                training_data.labels = [Label.from_dict(label) for label in json_dict["labels"]]
-            return training_data
-        else:
-            raise ValueError("The given json_dict is not a valid TrainingData")
+    labels: List[Label]
+    dataset_id: Optional[str]
+    training_type: Optional[str]
+    number_of_labels: Optional[int]
+    data_sources: Optional[Union[List[str], List[CICitation]]]
+    quality: Optional[DataQuality]
+    labeling: Optional[List[Labeling]]
+    quality: Optional[DataQuality]
 
 
-@dataclass
-class Changeset:
+class Changeset(BaseCamelModel):
     """
     Training Data Changeset
     """
+
+    type: Literal["AI_TDChangeset"]
     id: str
     change_count: int
-    dataset_id: str = field(default=None)
-    version: str = field(default=None)
-    created_time: str = field(default=None)
-    add: List[TrainingData] = field(default_factory=list)
-    modify: List[TrainingData] = field(default_factory=list)
-    delete: List[TrainingData] = field(default_factory=list)
 
-    def to_dict(self):
-        return {
-            "type": "TDChangeset",
-            "id": self.id,
-            "changeCount": self.change_count,
-            "datasetId": self.dataset_id,
-            "version": self.version,
-            "createdTime": self.created_time,
-            "add": [td.to_dict() for td in self.add],
-            "modify": [td.to_dict() for td in self.modify],
-            "delete": [td.to_dict() for td in self.delete],
-        }
+    add: Optional[List[TrainingData]]
+    change_count: Optional[int]
+    dataset_id: Optional[str]
+    delete: Optional[List[TrainingData]]
+    modify: Optional[List[TrainingData]]
+    version: Optional[str]
+    created_time: Optional[str]
 
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict.__contains__("changeCount") \
-                and json_dict["type"] == "TDChangeset":
-            changeset = Changeset(json_dict["id"], json_dict["changeCount"])
-            if json_dict.__contains__("datasetId"):
-                changeset.dataset_id = json_dict["datasetId"]
-            if json_dict.__contains__("version"):
-                changeset.version = json_dict["version"]
-            if json_dict.__contains__("createdTime"):
-                changeset.created_time = json_dict["createdTime"]
-            if json_dict.__contains__("add"):
-                changeset.add = [TrainingData.from_dict(td) for td in json_dict["add"]]
-            if json_dict.__contains__("modify"):
-                changeset.add = [TrainingData.from_dict(td) for td in json_dict["modify"]]
-            if json_dict.__contains__("delete"):
-                changeset.add = [TrainingData.from_dict(td) for td in json_dict["delete"]]
-            return changeset
-        else:
-            raise ValueError("The given json_dict is not a valid Changeset")
+    @validator("created_time")
+    def validate_created_time(cls, v):
+        return _validate_date(v)
 
 
-@dataclass
-class TrainingDataset:
+class StatisticsInfoType(BaseCamelModel):
+    """
+    Statistics info type
+    """
+
+    key: str
+    value: int
+
+
+class StatisticsInfo(BaseCamelModel):
+    """
+    Statistics info
+    """
+
+    type: Optional[List[StatisticsInfoType]] = Field(min_items=1)
+
+
+class TrainingDataset(BaseCamelModel):
     """
     Basic training dataset type
     """
+
     id: str
     name: str
     description: str
     license: str
-    doi: str = field(default=None)
-    scope: Scope = field(default=None)
-    version: str = field(default=None)
-    amount_of_training_data: int = field(default=None)
-    created_time: str = field(default=None)
-    updated_time: str = field(default=None)
-    providers: List[str] = field(default_factory=list)
-    keywords: List[str] = field(default_factory=list)
-    metrics_in_literature: List[MetricsInLiterature] = field(default_factory=list)
-    statistics_info: List[KeyValuePair] = field(default_factory=list)
-    dataSources: List[str] = field(default_factory=list)
-    number_of_classes: int = field(default=None)
-    classification_schema: str = field(default=None)
-    classes: Union[List[KeyValuePair], List[str]] = field(default=None)
-    tasks: List[Task] = field(default_factory=list)
-    labeling: List[Labeling] = field(default_factory=list)
-    quality: DataQuality = field(default=None)
-    changesets: List[Changeset] = field(default_factory=list)
-    data: List[TrainingData] = field(default_factory=list)
+    tasks: List[Task]
+    data: Union[List[TrainingData], str]  # That one should be uri-format
 
-    def get_training_data(self) -> List[TrainingData]:
-        """
-        Return the training data of the training dataset
-        """
-        return self.data
+    amount_of_training_data: Optional[int]
+    classes: Optional[List[Union[KeyValuePair, str, Dict]]] = Field(min_items=1)
+    classification_schema: Optional[str]  # That one should be uri-format
+    created_time: Optional[str]
+    dataSources: Optional[
+        Union[List[str], List[CICitation]]
+    ]  # That string one should be uri-format
+    doi: Optional[str]
+    keywords: Optional[List[str]]
+    number_of_classes: Optional[int]
+    scope: Optional[MD_Scope]
+    version: Optional[str]
+    updated_time: Optional[str]
+    labeling: Optional[List[Labeling]]
+    metrics_in_LIT: Optional[List[MetricsInLiterature]]
+    quality: Optional[DataQuality]
+    providers: Optional[List[str]]
+    statistics_info: Optional[StatisticsInfo]
 
-    def get_training_data_by_id(self, _id: str) -> TrainingData:
-        """
-        Get training data of the training dataset by id
-        """
-        for data in self.data:
-            if data.id == _id:
-                return data
+    @validator("created_time")
+    def validate_created_time(cls, v):
+        return _validate_date(v)
 
-    def get_labelings(self) -> List[Labeling]:
-        """
-        Return the labeling of the training dataset
-        """
-        return self.labeling
-
-    def get_tasks(self) -> List[Task]:
-        """
-        Return the tasks of the training dataset
-        """
-        return self.tasks
-
-    def get_quality(self) -> DataQuality:
-        """
-        Return the quality of the training dataset
-        """
-        return self.quality
-
-    def get_changesets(self) -> List[Changeset]:
-        """
-        Return the changesets of the training dataset
-        """
-        return self.changesets
-
-    def to_dict(self):
-        return {
-            "type": "TrainingDataset",
-            "id": self.id,
-            "name": self.name,
-            "description": self.description,
-            "license": self.license,
-            "doi": self.doi,
-            "scope": self.scope.to_dict() if self.scope is not None else None,
-            "version": self.version,
-            "amountOfTrainingData": self.amount_of_training_data,
-            "createdTime": self.created_time,
-            "updatedTime": self.updated_time,
-            "providers": self.providers,
-            "keywords": self.keywords,
-            "metricsInLIT": [m.to_dict() for m in self.metrics_in_literature],
-            "statisticsInfo": [s.to_dict() for s in self.statistics_info],
-            "numberOfClasses": self.number_of_classes,
-            "classificationSchema": self.classification_schema,
-            "classes": self.classes,
-            "tasks": [t.to_dict() for t in self.tasks],
-            "labeling": [ll.to_dict() for ll in self.labeling],
-            "quality": self.quality.to_dict() if self.quality is not None else None,
-            "changesets": [changeset.to_dict() for changeset in self.changesets],
-            "data": [d.to_dict() for d in self.data]
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict.__contains__("name") \
-                and json_dict.__contains__("description") and json_dict.__contains__("license") \
-                and json_dict["type"] == "TrainingDataset":
-            td = TrainingDataset(json_dict["id"], json_dict["name"], json_dict["description"], json_dict["license"])
-            if json_dict.__contains__("doi"):
-                td.doi = json_dict["doi"]
-            if json_dict.__contains__("scope"):
-                td.scope = Scope.from_dict(json_dict["scope"])
-            if json_dict.__contains__("version"):
-                td.version = json_dict["version"]
-            if json_dict.__contains__("amountOfTrainingData"):
-                td.amount_of_training_data = json_dict["amountOfTrainingData"]
-            if json_dict.__contains__("createdTime"):
-                td.created_time = json_dict["createdTime"]
-            if json_dict.__contains__("updatedTime"):
-                td.updated_time = json_dict["updatedTime"]
-            if json_dict.__contains__("providers"):
-                td.providers = json_dict["providers"]
-            if json_dict.__contains__("keywords"):
-                td.keywords = json_dict["keywords"]
-            if json_dict.__contains__("metricsInLIT"):
-                td.metrics_in_literature = [MetricsInLiterature.from_dict(m) for m in
-                                            json_dict["metricsInLIT"]]
-            if json_dict.__contains__("statisticsInfo"):
-                td.statistics_info = [KeyValuePair.from_dict(s) for s in json_dict["statisticsInfo"]]
-            if json_dict.__contains__("numberOfClasses"):
-                td.number_of_classes = json_dict["numberOfClasses"]
-            if json_dict.__contains__("classificationSchema"):
-                td.classification_schema = json_dict["classificationSchema"]
-            if json_dict.__contains__("classes"):
-                td.classes = json_dict["classes"]
-            if json_dict.__contains__("tasks"):
-                td.tasks = [Task.from_dict(t) for t in json_dict["tasks"]]
-            if json_dict.__contains__("labeling"):
-                td.labeling = [Labeling.from_dict(labeling) for labeling in json_dict["labeling"]]
-            if json_dict.__contains__("quality"):
-                td.quality = DataQuality.from_dict(json_dict["quality"])
-            if json_dict.__contains__("changesets"):
-                td.changesets = [Changeset.from_dict(changeset) for changeset in json_dict["changesets"]]
-            if json_dict.__contains__("data"):
-                td.data = [TrainingData.from_dict(data) for data in json_dict["data"]]
-            return td
-        else:
-            raise ValueError("The given json_dict is not a valid TrainingDataset")
+    @validator("updated_time")
+    def validate_updated_time(cls, v):
+        return _validate_date(v)

--- a/pytdml/type/basic_types_old.py
+++ b/pytdml/type/basic_types_old.py
@@ -1,0 +1,647 @@
+# ------------------------------------------------------------------------------
+#
+# Project: pytdml
+# Authors: Boyi Shangguan, Kaixuan Wang, Zhaoyan Wu
+# Created: 2022-05-04
+# Modified: 2023-10-27
+# Email: sgby@whu.edu.cn
+#
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2022 OGC Training Data Markup Language for AI Standard Working Group
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ------------------------------------------------------------------------------
+from dataclasses import dataclass, field
+from typing import List, Union
+
+
+@dataclass
+class KeyValuePair:
+    """
+    Key/Value pair type
+    """
+
+    key: str
+    value: Union[str, int, float, bool, None]
+
+    def to_dict(self):
+        return {self.key: self.value}
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if len(json_dict.keys()) == 1:
+            for key in json_dict.keys():
+                return KeyValuePair(key, json_dict[key])
+        else:
+            raise ValueError("The given json_dict is not a valid KeyValuePair")
+
+
+@dataclass
+class MetricsInLiterature:
+    """
+    Metrics in literature type
+    """
+
+    doi: str
+    algorithm: str = field(default=None)
+    metrics: List[KeyValuePair] = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "doi": self.doi,
+            "algorithm": self.algorithm,
+            "metrics": [m.to_dict() for m in self.metrics],
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("doi"):
+            metrics_in_literature = MetricsInLiterature(json_dict["doi"])
+            if json_dict.__contains__("algorithm"):
+                metrics_in_literature.algorithm = json_dict["algorithm"]
+            if json_dict.__contains__("metrics"):
+                metrics_in_literature.metrics = [
+                    KeyValuePair.from_dict(m) for m in json_dict["metrics"]
+                ]
+            return metrics_in_literature
+        else:
+            raise ValueError("The given json_dict is not a valid MetricsInLiterature")
+
+
+@dataclass
+class Task:
+    """
+    Basic task type
+    """
+
+    id: str
+    dataset_id: str = field(default=None)
+    description: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "Task",
+            "id": self.id,
+            "datasetId": self.dataset_id,
+            "description": self.description,
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict["type"] == "Task":
+            task = Task(json_dict["id"])
+            if json_dict.__contains__("datasetId"):
+                task.dataset_id = json_dict["datasetId"]
+            if json_dict.__contains__("description"):
+                task.description = json_dict["description"]
+            return task
+        else:
+            raise ValueError("The given json_dict is not a valid Task")
+
+
+@dataclass
+class Labeler:
+    """
+    Labeler type
+    """
+
+    id: str
+    name: str = field(default=None)
+
+    def to_dict(self):
+        return {"type": "Labeler", "id": self.id, "name": self.name}
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict["type"] == "Labeler":
+            labeler = Labeler(json_dict["id"])
+            if json_dict.__contains__("name"):
+                labeler.name = json_dict["name"]
+            return labeler
+        else:
+            raise ValueError("The given json_dict is not a valid Labeler")
+
+
+@dataclass
+class LabelingProcedure:
+    """
+    Labeling procedure type
+    """
+
+    id: str
+    methods: List[str] = field(default_factory=list)
+    tools: List[str] = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "type": "LabelingProcedure",
+            "id": self.id,
+            "methods": self.methods,
+            "tools": self.tools,
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict["type"] == "LabelingProcedure":
+            labeling_procedure = LabelingProcedure(json_dict["id"])
+            if json_dict.__contains__("methods"):
+                labeling_procedure.method = json_dict["methods"]
+            if json_dict.__contains__("tools"):
+                labeling_procedure.tool = json_dict["tools"]
+            return labeling_procedure
+        else:
+            raise ValueError("The given json_dict is not a valid LabelingProcedure")
+
+
+@dataclass
+class Labeling:
+    """
+    Labeling type
+    """
+
+    id: str
+    scope: object
+    labelers: List[Labeler] = field(default_factory=list)
+    procedure: LabelingProcedure = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "Labeling",
+            "id": self.id,
+            "scope": self.scope,
+            "labelers": [labeler.to_dict() for labeler in self.labelers],
+            "procedure": self.procedure.to_dict()
+            if self.procedure is not None
+            else None,
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if (
+            json_dict.__contains__("id")
+            and json_dict.__contains__("scope")
+            and json_dict["type"] == "Labeling"
+        ):
+            labeling = Labeling(json_dict["id"], json_dict["scope"])
+            if json_dict.__contains__("labelers"):
+                labeling.labelers = [
+                    Labeler.from_dict(labeler) for labeler in json_dict["labelers"]
+                ]
+            if json_dict.__contains__("procedure"):
+                labeling.procedure = LabelingProcedure.from_dict(json_dict["procedure"])
+            return labeling
+        else:
+            raise ValueError("The given json_dict is not a valid Labeling")
+
+
+@dataclass
+class ScopeDescription:
+    """
+    From ISO 19115-1 MD_ScopeDescription
+    """
+
+    attributes: List[str] = field(default_factory=list)
+    features: List[str] = field(default_factory=list)
+    featureInstances: List[str] = field(default_factory=list)
+    attributeInstances: List[str] = field(default_factory=list)
+    dataset: str = field(default=None)
+    other: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "attributes": self.attributes,
+            "features": self.features,
+            "featureInstances": self.featureInstances,
+            "attributeInstances": self.attributeInstances,
+            "dataset": self.dataset,
+            "other": self.other,
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        sd = ScopeDescription()
+        if json_dict.__contains__("attributes"):
+            sd.attributes = json_dict["attributes"]
+        if json_dict.__contains__("features"):
+            sd.features = json_dict["features"]
+        if json_dict.__contains__("featureInstances"):
+            sd.featureInstances = json_dict["featureInstances"]
+        if json_dict.__contains__("attributeInstances"):
+            sd.attributeInstances = json_dict["attributeInstances"]
+        if json_dict.__contains__("dataset"):
+            sd.dataset = json_dict["dataset"]
+        if json_dict.__contains__("other"):
+            sd.other = json_dict["other"]
+        return sd
+
+
+@dataclass
+class MD_Scope:
+    """
+    From ISO 19115-1 MD_Scope
+    """
+
+    level: str
+    levelDescription: List[ScopeDescription] = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "level": self.level,
+            "levelDescription": [ld.to_dict for ld in self.levelDescription],
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("level"):
+            scope = MD_Scope(json_dict["level"])
+            if json_dict.__contains__("levelDescription"):
+                scope.levelDescription = [
+                    ScopeDescription.from_dict(ld)
+                    for ld in json_dict["levelDescription"]
+                ]
+            return scope
+        else:
+            raise ValueError("The given json_dict is not a valid Scope")
+
+
+@dataclass
+class QualityElement:
+    """
+    From ISO 19157-1 QualityElement
+    """
+
+    type: str = field(default=None)
+    measure: str = field(default=None)
+    evaluation_method: str = field(default=None)
+    result: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": self.type,
+            "measure": self.measure,
+            "evaluationMethod": self.evaluation_method,
+            "result": self.result,
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        quality_element = QualityElement()
+        if json_dict.__contains__("type"):
+            quality_element.type = json_dict["type"]
+        if json_dict.__contains__("measure"):
+            quality_element.measure = json_dict["measure"]
+        if json_dict.__contains__("evaluationMethod"):
+            quality_element.evaluation_method = json_dict["evaluationMethod"]
+        if json_dict.__contains__("result"):
+            quality_element.result = json_dict["resule"]
+        return quality_element
+
+
+@dataclass
+class DataQuality:
+    """
+    From ISO 19157-1 DataQuality
+    """
+
+    scope: MD_Scope
+    report: List[QualityElement] = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "scope": self.scope.to_dict() if self.scope is not None else None,
+            "report": [r.to_dict() for r in self.report],
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("scope"):
+            data_quality = DataQuality(scope=MD_Scope.from_dict(json_dict["scope"]))
+            if json_dict.__contains__("report"):
+                data_quality.report = [
+                    QualityElement.from_dict(element) for element in json_dict["report"]
+                ]
+            return data_quality
+        else:
+            raise ValueError("The given json_dict is not a valid DataQuality")
+
+
+@dataclass
+class Label:
+    """
+    Basic label type
+    """
+
+    is_negative: bool = field(default=None)
+    confidence: float = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "Label",
+            "isNegative": self.is_negative,
+            "confidence": self.confidence,
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict["type"] == "Label":
+            label = Label()
+            if json_dict.__contains__("isNegative"):
+                label.is_negative = json_dict["isNegative"]
+            if json_dict.__contains__("confidence"):
+                label.confidence = json_dict["confidence"]
+            return label
+        else:
+            raise ValueError("The given json_dict is not a valid Label")
+
+
+@dataclass
+class TrainingData:
+    """
+    Basic training data type
+    """
+
+    id: str
+    dataset_id: str = field(default=None)
+    training_type: str = field(default=None)
+    number_of_labels: int = field(default=None)
+    data_sources: List[str] = field(default_factory=list)
+    quality: DataQuality = field(default=None)
+    labeling: List[Labeling] = field(default_factory=list)
+    labels: List[Label] = field(default_factory=list)
+
+    def get_labels(self) -> List[Label]:
+        """
+        Returns the labels of the training data
+        """
+        return self.labels
+
+    def to_dict(self):
+        return {
+            "type": "TrainingData",
+            "id": self.id,
+            "trainingType": self.training_type,
+            "numberOfLabels": self.number_of_labels,
+            "dataSources": self.data_sources,
+            "quality": self.quality.to_dict() if self.quality is not None else None,
+            "labeling": [ll.to_dict() for ll in self.labeling],
+            "labels": [label.to_dict() for label in self.labels],
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict["type"] == "TrainingData":
+            training_data = TrainingData(json_dict["id"])
+            if json_dict.__contains__("trainingType"):
+                training_data.training_type = json_dict["trainingType"]
+            if json_dict.__contains__("numberOfLabels"):
+                training_data.number_of_labels = json_dict["numberOfLabels"]
+            if json_dict.__contains__("dataSources"):
+                training_data.data_sources = json_dict["dataSources"]
+            if json_dict.__contains__("quality"):
+                training_data.quality = DataQuality.from_dict(json_dict["quality"])
+            if json_dict.__contains__("labeling"):
+                training_data.labeling = [
+                    Labeling.from_dict(ll) for ll in json_dict["labeling"]
+                ]
+            if json_dict.__contains__("labels"):
+                training_data.labels = [
+                    Label.from_dict(label) for label in json_dict["labels"]
+                ]
+            return training_data
+        else:
+            raise ValueError("The given json_dict is not a valid TrainingData")
+
+
+@dataclass
+class Changeset:
+    """
+    Training Data Changeset
+    """
+
+    id: str
+    change_count: int
+    dataset_id: str = field(default=None)
+    version: str = field(default=None)
+    created_time: str = field(default=None)
+    add: List[TrainingData] = field(default_factory=list)
+    modify: List[TrainingData] = field(default_factory=list)
+    delete: List[TrainingData] = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "type": "TDChangeset",
+            "id": self.id,
+            "changeCount": self.change_count,
+            "datasetId": self.dataset_id,
+            "version": self.version,
+            "createdTime": self.created_time,
+            "add": [td.to_dict() for td in self.add],
+            "modify": [td.to_dict() for td in self.modify],
+            "delete": [td.to_dict() for td in self.delete],
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if (
+            json_dict.__contains__("id")
+            and json_dict.__contains__("changeCount")
+            and json_dict["type"] == "TDChangeset"
+        ):
+            changeset = Changeset(json_dict["id"], json_dict["changeCount"])
+            if json_dict.__contains__("datasetId"):
+                changeset.dataset_id = json_dict["datasetId"]
+            if json_dict.__contains__("version"):
+                changeset.version = json_dict["version"]
+            if json_dict.__contains__("createdTime"):
+                changeset.created_time = json_dict["createdTime"]
+            if json_dict.__contains__("add"):
+                changeset.add = [TrainingData.from_dict(td) for td in json_dict["add"]]
+            if json_dict.__contains__("modify"):
+                changeset.add = [
+                    TrainingData.from_dict(td) for td in json_dict["modify"]
+                ]
+            if json_dict.__contains__("delete"):
+                changeset.add = [
+                    TrainingData.from_dict(td) for td in json_dict["delete"]
+                ]
+            return changeset
+        else:
+            raise ValueError("The given json_dict is not a valid Changeset")
+
+
+@dataclass
+class TrainingDataset:
+    """
+    Basic training dataset type
+    """
+
+    id: str
+    name: str
+    description: str
+    license: str
+    doi: str = field(default=None)
+    scope: MD_Scope = field(default=None)
+    version: str = field(default=None)
+    amount_of_training_data: int = field(default=None)
+    created_time: str = field(default=None)
+    updated_time: str = field(default=None)
+    providers: List[str] = field(default_factory=list)
+    keywords: List[str] = field(default_factory=list)
+    metrics_in_literature: List[MetricsInLiterature] = field(default_factory=list)
+    statistics_info: List[KeyValuePair] = field(default_factory=list)
+    dataSources: List[str] = field(default_factory=list)
+    number_of_classes: int = field(default=None)
+    classification_schema: str = field(default=None)
+    classes: Union[List[KeyValuePair], List[str]] = field(default=None)
+    tasks: List[Task] = field(default_factory=list)
+    labeling: List[Labeling] = field(default_factory=list)
+    quality: DataQuality = field(default=None)
+    changesets: List[Changeset] = field(default_factory=list)
+    data: List[TrainingData] = field(default_factory=list)
+
+    def get_training_data(self) -> List[TrainingData]:
+        """
+        Return the training data of the training dataset
+        """
+        return self.data
+
+    def get_training_data_by_id(self, _id: str) -> TrainingData:
+        """
+        Get training data of the training dataset by id
+        """
+        for data in self.data:
+            if data.id == _id:
+                return data
+
+    def get_labelings(self) -> List[Labeling]:
+        """
+        Return the labeling of the training dataset
+        """
+        return self.labeling
+
+    def get_tasks(self) -> List[Task]:
+        """
+        Return the tasks of the training dataset
+        """
+        return self.tasks
+
+    def get_quality(self) -> DataQuality:
+        """
+        Return the quality of the training dataset
+        """
+        return self.quality
+
+    def get_changesets(self) -> List[Changeset]:
+        """
+        Return the changesets of the training dataset
+        """
+        return self.changesets
+
+    def to_dict(self):
+        return {
+            "type": "TrainingDataset",
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "license": self.license,
+            "doi": self.doi,
+            "scope": self.scope.to_dict() if self.scope is not None else None,
+            "version": self.version,
+            "amountOfTrainingData": self.amount_of_training_data,
+            "createdTime": self.created_time,
+            "updatedTime": self.updated_time,
+            "providers": self.providers,
+            "keywords": self.keywords,
+            "metricsInLIT": [m.to_dict() for m in self.metrics_in_literature],
+            "statisticsInfo": [s.to_dict() for s in self.statistics_info],
+            "numberOfClasses": self.number_of_classes,
+            "classificationSchema": self.classification_schema,
+            "classes": self.classes,
+            "tasks": [t.to_dict() for t in self.tasks],
+            "labeling": [ll.to_dict() for ll in self.labeling],
+            "quality": self.quality.to_dict() if self.quality is not None else None,
+            "changesets": [changeset.to_dict() for changeset in self.changesets],
+            "data": [d.to_dict() for d in self.data],
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if (
+            json_dict.__contains__("id")
+            and json_dict.__contains__("name")
+            and json_dict.__contains__("description")
+            and json_dict.__contains__("license")
+            and json_dict["type"] == "TrainingDataset"
+        ):
+            td = TrainingDataset(
+                json_dict["id"],
+                json_dict["name"],
+                json_dict["description"],
+                json_dict["license"],
+            )
+            if json_dict.__contains__("doi"):
+                td.doi = json_dict["doi"]
+            if json_dict.__contains__("scope"):
+                td.scope = MD_Scope.from_dict(json_dict["scope"])
+            if json_dict.__contains__("version"):
+                td.version = json_dict["version"]
+            if json_dict.__contains__("amountOfTrainingData"):
+                td.amount_of_training_data = json_dict["amountOfTrainingData"]
+            if json_dict.__contains__("createdTime"):
+                td.created_time = json_dict["createdTime"]
+            if json_dict.__contains__("updatedTime"):
+                td.updated_time = json_dict["updatedTime"]
+            if json_dict.__contains__("providers"):
+                td.providers = json_dict["providers"]
+            if json_dict.__contains__("keywords"):
+                td.keywords = json_dict["keywords"]
+            if json_dict.__contains__("metricsInLIT"):
+                td.metrics_in_literature = [
+                    MetricsInLiterature.from_dict(m) for m in json_dict["metricsInLIT"]
+                ]
+            if json_dict.__contains__("statisticsInfo"):
+                td.statistics_info = [
+                    KeyValuePair.from_dict(s) for s in json_dict["statisticsInfo"]
+                ]
+            if json_dict.__contains__("numberOfClasses"):
+                td.number_of_classes = json_dict["numberOfClasses"]
+            if json_dict.__contains__("classificationSchema"):
+                td.classification_schema = json_dict["classificationSchema"]
+            if json_dict.__contains__("classes"):
+                td.classes = json_dict["classes"]
+            if json_dict.__contains__("tasks"):
+                td.tasks = [Task.from_dict(t) for t in json_dict["tasks"]]
+            if json_dict.__contains__("labeling"):
+                td.labeling = [
+                    Labeling.from_dict(labeling) for labeling in json_dict["labeling"]
+                ]
+            if json_dict.__contains__("quality"):
+                td.quality = DataQuality.from_dict(json_dict["quality"])
+            if json_dict.__contains__("changesets"):
+                td.changesets = [
+                    Changeset.from_dict(changeset)
+                    for changeset in json_dict["changesets"]
+                ]
+            if json_dict.__contains__("data"):
+                td.data = [TrainingData.from_dict(data) for data in json_dict["data"]]
+            return td
+        else:
+            raise ValueError("The given json_dict is not a valid TrainingDataset")

--- a/pytdml/type/extended_types.py
+++ b/pytdml/type/extended_types.py
@@ -1,8 +1,9 @@
 # ------------------------------------------------------------------------------
 #
 # Project: pytdml
-# Authors: Boyi Shangguan, Kaixuan Wang
+# Authors: Boyi Shangguan, Kaixuan Wang, Zhaoyan Wu
 # Created: 2022-05-04
+# Modified: 2023-10-27
 # Email: sgby@whu.edu.cn
 #
 # ------------------------------------------------------------------------------
@@ -28,344 +29,88 @@
 # SOFTWARE.
 #
 # ------------------------------------------------------------------------------
-from dataclasses import dataclass, field
-from typing import List, Union
 
-import geojson
+import json
 from geojson import Feature
-from pytdml.type.basic_types import Label, TrainingData, TrainingDataset, DataQuality, Task, \
-    MetricsInLiterature, \
-    KeyValuePair, Labeling, Changeset, Scope
+from typing import List, Union, Optional, Literal
+from pydantic import Field, validator 
+
+from pytdml.type.basic_types import Label, TrainingDataset, TrainingData, _validate_date, Task, MD_Band
 
 
-@dataclass
-class SceneLabel(Label):
-    """
-    Extended label type for scene level training data
-    """
-    label_class: str = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "SceneLabel",
-            "isNegative": self.is_negative,
-            "confidence": self.confidence,
-            'class': self.label_class
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("class") and json_dict["type"] == "SceneLabel":
-            label = SceneLabel(label_class=json_dict["class"])
-            if json_dict.__contains__("isNegative"):
-                label.is_negative = json_dict["isNegative"]
-            if json_dict.__contains__("confidence"):
-                label.confidence = json_dict["confidence"]
-            return label
-        else:
-            raise ValueError("The given json_dict is not a valid SceneLabel")
-
-
-@dataclass
-class ObjectLabel(Label):
-    """
-    Extended label type for object level training data
-    """
-    type: str = "ObjectLabel"
-    object: Feature = field(default=None)
-    label_class: str = field(default=None)
-    bbox_type: str = field(default=None)
-    is_difficultly_detectable: bool = field(default=None)
-    date_time: str = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "ObjectLabel",
-            "isNegative": self.is_negative,
-            "confidence": self.confidence,
-            'object': self.object,
-            'bboxType': self.bbox_type,
-            'class': self.label_class,
-            'isDiffDetectable': self.is_difficultly_detectable,
-            'dateTime': self.date_time
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("object") and json_dict["type"] == "ObjectLabel":
-            label = ObjectLabel(object=geojson.loads(json_dict["object"].__str__().replace("'", "\"")))
-            if json_dict.__contains__("isNegative"):
-                label.is_negative = json_dict["isNegative"]
-            if json_dict.__contains__("confidence"):
-                label.confidence = json_dict["confidence"]
-            if json_dict.__contains__("bboxType"):
-                label.bbox_type = json_dict["bboxType"]
-            if json_dict.__contains__("class"):
-                label.label_class = json_dict["class"]
-            if json_dict.__contains__("isDiffDetectable"):
-                label.is_difficultly_detectable = json_dict["isDiffDetectable"]
-            if json_dict.__contains__("dateTime"):
-                label.date_time = json_dict["dateTime"]
-            return label
-        else:
-            raise ValueError("The given json_dict is not a valid ObjectLabel")
-
-
-@dataclass
 class PixelLabel(Label):
     """
     Extended label type for pixel level training data
     """
-    type: str = "PixelLabel"
-    image_url: Union[str, List[str]] = field(default=None)
-    image_format: Union[str, List[str]] = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "PixelLabel",
-            "isNegative": self.is_negative,
-            "confidence": self.confidence,
-            "imageURL": self.image_url,
-            "imageFormat": self.image_format
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("imageURL") and json_dict.__contains__("imageFormat") \
-                and json_dict["type"] == "PixelLabel":
-            label = PixelLabel(image_url=json_dict["imageURL"], image_format=json_dict["imageFormat"])
-            if json_dict.__contains__("isNegative"):
-                label.is_negative = json_dict["isNegative"]
-            if json_dict.__contains__("confidence"):
-                label.confidence = json_dict["confidence"]
-            return label
-        else:
-            raise ValueError("The given json_dict is not a valid PixelLabel")
+    type: Literal["AI_PixelLabel"]
+    image_URL: List[str] = Field(min_items=1)
+    image_format: List[str] = Field(min_items=1)
 
 
-# @dataclass
-# class EODataSource:
-#     """
-#     EO data source type
-#     """
-#     id: str
-#     data_type: str = field(default=None)
-#     citation: str = field(default=None)
-#     platform: str = field(default=None)
-#     sensor: str = field(default=None)
-#     resolution: str = field(default=None)
-#     format: str = field(default=None)
-#
-#     def to_dict(self):
-#         return {
-#             'id': self.id,
-#             'dataType': self.data_type,
-#             'citation': self.citation,
-#             'platform': self.platform,
-#             'sensor': self.sensor,
-#             'resolution': self.resolution,
-#             'format': self.format
-#         }
-#
-#     @staticmethod
-#     def from_dict(json_dict: dict):
-#         if json_dict.__contains__("id"):
-#             data_source = EODataSource(json_dict["id"])
-#             if json_dict.__contains__("dataType"):
-#                 data_source.data_type = json_dict["dataType"]
-#             if json_dict.__contains__("citation"):
-#                 data_source.citation = json_dict["citation"]
-#             if json_dict.__contains__("platform"):
-#                 data_source.platform = json_dict["platform"]
-#             if json_dict.__contains__("sensor"):
-#                 data_source.sensor = json_dict["sensor"]
-#             if json_dict.__contains__("resolution"):
-#                 data_source.resolution = json_dict["resolution"]
-#             if json_dict.__contains__("format"):
-#                     data_source.resolution = json_dict["format"]
-#             return data_source
-#         else:
-#             raise ValueError("The given json_dict is not a valid EODataSource")
+class ObjectLabel(Label):
+    """
+    Extended label type for object level training data
+    """
+    type: Literal["AI_ObjectLabel"]
+    object: Feature
+    label_class: str = Field(alias="class")
+    date_time: Optional[str]
+    bbox_type: Optional[str]
+    
+    @validator("date_time")
+    def validate_date_time(cls, v):
+        return _validate_date(v)
 
-
-@dataclass
+    
+class SceneLabel(Label):
+    """
+    Extended label type for scene level training data
+    """
+    type: Literal["AI_SceneLabel"]
+    label_class: str = Field(alias="class")
+    
 class EOTask(Task):
     """
     Extended task type for EO training data
     """
-    type: str = "EOTask"
-    task_type: str = field(default=None)
-
-    def to_dict(self):
-        return {
-            "type": "EOTask",
-            "id": self.id,
-            "datasetId": self.dataset_id,
-            "description": self.description,
-            "taskType": self.task_type
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict.__contains__("type") and json_dict["type"] == "EOTask":
-            task = EOTask(json_dict["id"])
-            if json_dict.__contains__("datasetId"):
-                task.dataset_id = json_dict["datasetId"]
-            if json_dict.__contains__("description"):
-                task.description = json_dict["description"]
-            if json_dict.__contains__("taskType"):
-                task.task_type = json_dict["taskType"]
-            return task
-        else:
-            raise ValueError("The given json_dict is not a valid EOTask")
-
-
-@dataclass
+    type: Literal["AI_EOTask"]
+    task_type: str
+    
 class EOTrainingData(TrainingData):
     """
     Extended training data type for EO training data
     """
-    type: str  = "EOTrainingData"
-    extent: List[float] = field(default_factory=list)
-    date_time: Union[str, List[str]] = field(default=None)
-    data_url: Union[str, List[str]] = field(default=None)
+    type: Literal["AI_EOTrainingData"]
+    data_URL: List[str] = Field(min_items=1)
+    extent: Optional[List[float]] = Field(min_items=4)
+    data_time: Optional[List[str]]
+    labels: List[Union[PixelLabel, ObjectLabel, SceneLabel]]
+    
+    @validator("data_time")
+    def validate_data_time(cls, v):
+        validated_data = []
+        for item in v:
+            validated_data.append(_validate_date(item))
+        return validated_data
 
-    def to_dict(self):
-        return {
-            "type": "EOTrainingData",
-            "id": self.id,
-            "trainingType": self.training_type,
-            "numberOfLabels": self.number_of_labels,
-            "dataSources": self.data_sources,
-            'extent': self.extent,
-            'dateTime': self.date_time,
-            'dataURL': self.data_url,
-            "quality": self.quality.to_dict() if self.quality is not None else None,
-            "labeling": [ll.to_dict() for ll in self.labeling],
-            "labels": [label.to_dict() for label in self.labels]
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict["type"] == "EOTrainingData":
-            training_data = EOTrainingData(json_dict["id"])
-            if json_dict.__contains__("trainingType"):
-                training_data.training_type = json_dict["trainingType"]
-            if json_dict.__contains__("numberOfLabels"):
-                training_data.number_of_labels = json_dict["numberOfLabels"]
-            if json_dict.__contains__("dataSources"):
-                training_data.data_sources = json_dict["dataSources"]
-            if json_dict.__contains__("quality"):
-                training_data.quality = DataQuality.from_dict(json_dict["quality"])
-            if json_dict.__contains__("labeling"):
-                training_data.labeling = [Labeling.from_dict(ll) for ll in json_dict["labeling"]]
-            if json_dict.__contains__("labels"):
-                # Different type of labels
-                if json_dict["labels"][0]["type"] == "SceneLabel":
-                    training_data.labels = [SceneLabel.from_dict(label) for label in json_dict["labels"]]
-                elif json_dict["labels"][0]["type"] == "ObjectLabel":
-                    training_data.labels = [ObjectLabel.from_dict(label) for label in json_dict["labels"]]
-                elif json_dict["labels"][0]["type"] == "PixelLabel":
-                    training_data.labels = [PixelLabel.from_dict(label) for label in json_dict["labels"]]
-            if json_dict.__contains__("extent"):
-                training_data.extent = json_dict["extent"]
-            if json_dict.__contains__("dateTime"):
-                training_data.date_time = json_dict["dateTime"]
-            if json_dict.__contains__("dataURL"):
-                training_data.data_url = json_dict["dataURL"]
-            return training_data
-        else:
-            raise ValueError("The given json_dict is not a valid EOTrainingData")
-
-
-@dataclass
 class EOTrainingDataset(TrainingDataset):
     """
     Extended training dataset type for EO training dataset
     """
-    extent: List[float] = field(default_factory=list)
-    bands: List[str] = field(default_factory=list)
-    image_size: str = field(default=None)
+    type: Literal["AI_EOTrainingDataset"]
+    # For Convinience, we allow the user to specify the bands by name
+    bands: Optional[List[Union[str,MD_Band]]]
+    extent: Optional[List[float]] = Field(min_items=4)
+    imageSize: Optional[str]
+    tasks: Optional[List[EOTask]]
+    data: List[EOTrainingData]
+    
 
-    def to_dict(self):
-        return {
-            "type": "EOTrainingDataset",
-            "id": self.id,
-            "name": self.name,
-            "description": self.description,
-            "license": self.license,
-            "doi": self.doi,
-            "scope": self.scope.to_dict() if self.scope is not None else None,
-            "version": self.version,
-            "amountOfTrainingData": self.amount_of_training_data,
-            "createdTime": self.created_time,
-            "updatedTime": self.updated_time,
-            "providers": self.providers,
-            "keywords": self.keywords,
-            "metricsInLIT": [m.to_dict() for m in self.metrics_in_literature],
-            "statisticsInfo": [s.to_dict() for s in self.statistics_info],
-            "numberOfClasses": self.number_of_classes,
-            "classificationSchema": self.classification_schema,
-            "classes": self.classes,
-            "tasks": [t.to_dict() for t in self.tasks],
-            'extent': self.extent,
-            'bands': self.bands,
-            'imageSize': self.image_size,
-            "labeling": [labeling.to_dict() for labeling in self.labeling],
-            "quality": self.quality.to_dict() if self.quality is not None else None,
-            "changesets": [changeset.to_dict() for changeset in self.changesets],
-            "data": [d.to_dict() for d in self.data]
-        }
-
-    @staticmethod
-    def from_dict(json_dict: dict):
-        if json_dict.__contains__("id") and json_dict.__contains__("name") \
-                and json_dict.__contains__("description") and json_dict.__contains__("license") \
-                and json_dict["type"] == "EOTrainingDataset":
-            td = EOTrainingDataset(json_dict["id"], json_dict["name"], json_dict["description"], json_dict["license"])
-            if json_dict.__contains__("doi"):
-                td.doi = json_dict["doi"]
-            if json_dict.__contains__("scope"):
-                td.scope = Scope.from_dict(json_dict["scope"])
-            if json_dict.__contains__("version"):
-                td.version = json_dict["version"]
-            if json_dict.__contains__("amountOfTrainingData"):
-                td.amount_of_training_data = json_dict["amountOfTrainingData"]
-            if json_dict.__contains__("createdTime"):
-                td.created_time = json_dict["createdTime"]
-            if json_dict.__contains__("updatedTime"):
-                td.updated_time = json_dict["updatedTime"]
-            if json_dict.__contains__("providers"):
-                td.providers = json_dict["providers"]
-            if json_dict.__contains__("keywords"):
-                td.keywords = json_dict["keywords"]
-            if json_dict.__contains__("metricsInLIT"):
-                td.metrics_in_literature = [MetricsInLiterature.from_dict(m) for m in
-                                            json_dict["metricsInLIT"]]
-            if json_dict.__contains__("statisticsInfo"):
-                td.statistics_info = [KeyValuePair.from_dict(s) for s in json_dict["statisticsInfo"]]
-            if json_dict.__contains__("numberOfClasses"):
-                td.number_of_classes = json_dict["numberOfClasses"]
-            if json_dict.__contains__("classificationSchema"):
-                td.classification_schema = json_dict["classificationSchema"]
-            if json_dict.__contains__("classes"):
-                td.classes = json_dict["classes"]
-            if json_dict.__contains__("tasks"):
-                td.tasks = [EOTask.from_dict(t) for t in json_dict["tasks"]]
-            if json_dict.__contains__("labeling"):
-                td.labeling = [Labeling.from_dict(labeling) for labeling in json_dict["labeling"]]
-            if json_dict.__contains__("quality"):
-                td.quality = DataQuality.from_dict(json_dict["quality"])
-            if json_dict.__contains__("changesets"):
-                td.changesets = [Changeset.from_dict(changeset) for changeset in json_dict["changesets"]]
-            if json_dict.__contains__("data"):
-                td.data = [EOTrainingData.from_dict(data) for data in json_dict["data"]]
-            if json_dict.__contains__("extent"):
-                td.extent = json_dict["extent"]
-            if json_dict.__contains__("bands"):
-                td.bands = json_dict["bands"]
-            if json_dict.__contains__("imageSize"):
-                td.image_size = json_dict["imageSize"]
-            return td
-        else:
-            raise ValueError("The given json_dict is not a valid EOTrainingDataset")
+if __name__ == "__main__":
+    tdml_path = r"C:\Users\zhaoyan\Desktop\TrainingDML-AI-master-use-cases-examples\use-cases\examples\1.0\WHU-building.json"
+    with open(tdml_path, 'r') as f:
+        data = json.load(f)
+    
+    td = EOTrainingDataset(**data).dict(by_alias=True,exclude_none=True)
+    print(td['data'])
+    Union[str, MD_Band]

--- a/pytdml/type/extended_types_old.py
+++ b/pytdml/type/extended_types_old.py
@@ -1,0 +1,372 @@
+# ------------------------------------------------------------------------------
+#
+# Project: pytdml
+# Authors: Boyi Shangguan, Kaixuan Wang, Zhaoyan Wu
+# Created: 2022-05-04
+# Modified: 2023-10-27
+# Email: sgby@whu.edu.cn
+#
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2022 OGC Training Data Markup Language for AI Standard Working Group
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ------------------------------------------------------------------------------
+from dataclasses import dataclass, field
+from typing import List, Union
+
+import geojson
+from geojson import Feature
+from pytdml.type.basic_types_old import Label, TrainingData, TrainingDataset, DataQuality, Task, \
+    MetricsInLiterature, \
+    KeyValuePair, Labeling, Changeset, MD_Scope
+
+
+@dataclass
+class SceneLabel(Label):
+    """
+    Extended label type for scene level training data
+    """
+    label_class: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "SceneLabel",
+            "isNegative": self.is_negative,
+            "confidence": self.confidence,
+            'class': self.label_class
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("class") and json_dict["type"] == "SceneLabel":
+            label = SceneLabel(label_class=json_dict["class"])
+            if json_dict.__contains__("isNegative"):
+                label.is_negative = json_dict["isNegative"]
+            if json_dict.__contains__("confidence"):
+                label.confidence = json_dict["confidence"]
+            return label
+        else:
+            raise ValueError("The given json_dict is not a valid SceneLabel")
+
+
+@dataclass
+class ObjectLabel(Label):
+    """
+    Extended label type for object level training data
+    """
+    type: str = "ObjectLabel"
+    object: Feature = field(default=None)
+    label_class: str = field(default=None)
+    bbox_type: str = field(default=None)
+    is_difficultly_detectable: bool = field(default=None)
+    date_time: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "ObjectLabel",
+            "isNegative": self.is_negative,
+            "confidence": self.confidence,
+            'object': self.object,
+            'bboxType': self.bbox_type,
+            'class': self.label_class,
+            'isDiffDetectable': self.is_difficultly_detectable,
+            'dateTime': self.date_time
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("object") and json_dict["type"] == "ObjectLabel":
+            label = ObjectLabel(object=geojson.loads(json_dict["object"].__str__().replace("'", "\"")))
+            if json_dict.__contains__("isNegative"):
+                label.is_negative = json_dict["isNegative"]
+            if json_dict.__contains__("confidence"):
+                label.confidence = json_dict["confidence"]
+            if json_dict.__contains__("bboxType"):
+                label.bbox_type = json_dict["bboxType"]
+            if json_dict.__contains__("class"):
+                label.label_class = json_dict["class"]
+            if json_dict.__contains__("isDiffDetectable"):
+                label.is_difficultly_detectable = json_dict["isDiffDetectable"]
+            if json_dict.__contains__("dateTime"):
+                label.date_time = json_dict["dateTime"]
+            return label
+        else:
+            raise ValueError("The given json_dict is not a valid ObjectLabel")
+
+
+@dataclass
+class PixelLabel(Label):
+    """
+    Extended label type for pixel level training data
+    """
+    type: str = "PixelLabel"
+    image_url: Union[str, List[str]] = field(default=None)
+    image_format: Union[str, List[str]] = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "PixelLabel",
+            "isNegative": self.is_negative,
+            "confidence": self.confidence,
+            "imageURL": self.image_url,
+            "imageFormat": self.image_format
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("imageURL") and json_dict.__contains__("imageFormat") \
+                and json_dict["type"] == "PixelLabel":
+            label = PixelLabel(image_url=json_dict["imageURL"], image_format=json_dict["imageFormat"])
+            if json_dict.__contains__("isNegative"):
+                label.is_negative = json_dict["isNegative"]
+            if json_dict.__contains__("confidence"):
+                label.confidence = json_dict["confidence"]
+            return label
+        else:
+            raise ValueError("The given json_dict is not a valid PixelLabel")
+
+
+# @dataclass
+# class EODataSource:
+#     """
+#     EO data source type
+#     """
+#     id: str
+#     data_type: str = field(default=None)
+#     citation: str = field(default=None)
+#     platform: str = field(default=None)
+#     sensor: str = field(default=None)
+#     resolution: str = field(default=None)
+#     format: str = field(default=None)
+#
+#     def to_dict(self):
+#         return {
+#             'id': self.id,
+#             'dataType': self.data_type,
+#             'citation': self.citation,
+#             'platform': self.platform,
+#             'sensor': self.sensor,
+#             'resolution': self.resolution,
+#             'format': self.format
+#         }
+#
+#     @staticmethod
+#     def from_dict(json_dict: dict):
+#         if json_dict.__contains__("id"):
+#             data_source = EODataSource(json_dict["id"])
+#             if json_dict.__contains__("dataType"):
+#                 data_source.data_type = json_dict["dataType"]
+#             if json_dict.__contains__("citation"):
+#                 data_source.citation = json_dict["citation"]
+#             if json_dict.__contains__("platform"):
+#                 data_source.platform = json_dict["platform"]
+#             if json_dict.__contains__("sensor"):
+#                 data_source.sensor = json_dict["sensor"]
+#             if json_dict.__contains__("resolution"):
+#                 data_source.resolution = json_dict["resolution"]
+#             if json_dict.__contains__("format"):
+#                     data_source.resolution = json_dict["format"]
+#             return data_source
+#         else:
+#             raise ValueError("The given json_dict is not a valid EODataSource")
+
+
+@dataclass
+class EOTask(Task):
+    """
+    Extended task type for EO training data
+    """
+    type: str = "EOTask"
+    task_type: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "EOTask",
+            "id": self.id,
+            "datasetId": self.dataset_id,
+            "description": self.description,
+            "taskType": self.task_type
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict.__contains__("type") and json_dict["type"] == "EOTask":
+            task = EOTask(json_dict["id"])
+            if json_dict.__contains__("datasetId"):
+                task.dataset_id = json_dict["datasetId"]
+            if json_dict.__contains__("description"):
+                task.description = json_dict["description"]
+            if json_dict.__contains__("taskType"):
+                task.task_type = json_dict["taskType"]
+            return task
+        else:
+            raise ValueError("The given json_dict is not a valid EOTask")
+
+
+@dataclass
+class EOTrainingData(TrainingData):
+    """
+    Extended training data type for EO training data
+    """
+    type: str  = "EOTrainingData"
+    extent: List[float] = field(default_factory=list)
+    date_time: Union[str, List[str]] = field(default=None)
+    data_url: Union[str, List[str]] = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "EOTrainingData",
+            "id": self.id,
+            "trainingType": self.training_type,
+            "numberOfLabels": self.number_of_labels,
+            "dataSources": self.data_sources,
+            'extent': self.extent,
+            'dateTime': self.date_time,
+            'dataURL': self.data_url,
+            "quality": self.quality.to_dict() if self.quality is not None else None,
+            "labeling": [ll.to_dict() for ll in self.labeling],
+            "labels": [label.to_dict() for label in self.labels]
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict["type"] == "EOTrainingData":
+            training_data = EOTrainingData(json_dict["id"])
+            if json_dict.__contains__("trainingType"):
+                training_data.training_type = json_dict["trainingType"]
+            if json_dict.__contains__("numberOfLabels"):
+                training_data.number_of_labels = json_dict["numberOfLabels"]
+            if json_dict.__contains__("dataSources"):
+                training_data.data_sources = json_dict["dataSources"]
+            if json_dict.__contains__("quality"):
+                training_data.quality = DataQuality.from_dict(json_dict["quality"])
+            if json_dict.__contains__("labeling"):
+                training_data.labeling = [Labeling.from_dict(ll) for ll in json_dict["labeling"]]
+            if json_dict.__contains__("labels"):
+                # Different type of labels
+                if json_dict["labels"][0]["type"] == "SceneLabel":
+                    training_data.labels = [SceneLabel.from_dict(label) for label in json_dict["labels"]]
+                elif json_dict["labels"][0]["type"] == "ObjectLabel":
+                    training_data.labels = [ObjectLabel.from_dict(label) for label in json_dict["labels"]]
+                elif json_dict["labels"][0]["type"] == "PixelLabel":
+                    training_data.labels = [PixelLabel.from_dict(label) for label in json_dict["labels"]]
+            if json_dict.__contains__("extent"):
+                training_data.extent = json_dict["extent"]
+            if json_dict.__contains__("dateTime"):
+                training_data.date_time = json_dict["dateTime"]
+            if json_dict.__contains__("dataURL"):
+                training_data.data_url = json_dict["dataURL"]
+            return training_data
+        else:
+            raise ValueError("The given json_dict is not a valid EOTrainingData")
+
+
+@dataclass
+class EOTrainingDataset(TrainingDataset):
+    """
+    Extended training dataset type for EO training dataset
+    """
+    extent: List[float] = field(default_factory=list)
+    bands: List[str] = field(default_factory=list)
+    image_size: str = field(default=None)
+
+    def to_dict(self):
+        return {
+            "type": "EOTrainingDataset",
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "license": self.license,
+            "doi": self.doi,
+            "scope": self.scope.to_dict() if self.scope is not None else None,
+            "version": self.version,
+            "amountOfTrainingData": self.amount_of_training_data,
+            "createdTime": self.created_time,
+            "updatedTime": self.updated_time,
+            "providers": self.providers,
+            "keywords": self.keywords,
+            "metricsInLIT": [m.to_dict() for m in self.metrics_in_literature],
+            "statisticsInfo": [s.to_dict() for s in self.statistics_info],
+            "numberOfClasses": self.number_of_classes,
+            "classificationSchema": self.classification_schema,
+            "classes": self.classes,
+            "tasks": [t.to_dict() for t in self.tasks],
+            'extent': self.extent,
+            'bands': self.bands,
+            'imageSize': self.image_size,
+            "labeling": [labeling.to_dict() for labeling in self.labeling],
+            "quality": self.quality.to_dict() if self.quality is not None else None,
+            "changesets": [changeset.to_dict() for changeset in self.changesets],
+            "data": [d.to_dict() for d in self.data]
+        }
+
+    @staticmethod
+    def from_dict(json_dict: dict):
+        if json_dict.__contains__("id") and json_dict.__contains__("name") \
+                and json_dict.__contains__("description") and json_dict.__contains__("license") \
+                and json_dict["type"] == "EOTrainingDataset":
+            td = EOTrainingDataset(json_dict["id"], json_dict["name"], json_dict["description"], json_dict["license"])
+            if json_dict.__contains__("doi"):
+                td.doi = json_dict["doi"]
+            if json_dict.__contains__("scope"):
+                td.scope = MD_Scope.from_dict(json_dict["scope"])
+            if json_dict.__contains__("version"):
+                td.version = json_dict["version"]
+            if json_dict.__contains__("amountOfTrainingData"):
+                td.amount_of_training_data = json_dict["amountOfTrainingData"]
+            if json_dict.__contains__("createdTime"):
+                td.created_time = json_dict["createdTime"]
+            if json_dict.__contains__("updatedTime"):
+                td.updated_time = json_dict["updatedTime"]
+            if json_dict.__contains__("providers"):
+                td.providers = json_dict["providers"]
+            if json_dict.__contains__("keywords"):
+                td.keywords = json_dict["keywords"]
+            if json_dict.__contains__("metricsInLIT"):
+                td.metrics_in_literature = [MetricsInLiterature.from_dict(m) for m in
+                                            json_dict["metricsInLIT"]]
+            if json_dict.__contains__("statisticsInfo"):
+                td.statistics_info = [KeyValuePair.from_dict(s) for s in json_dict["statisticsInfo"]]
+            if json_dict.__contains__("numberOfClasses"):
+                td.number_of_classes = json_dict["numberOfClasses"]
+            if json_dict.__contains__("classificationSchema"):
+                td.classification_schema = json_dict["classificationSchema"]
+            if json_dict.__contains__("classes"):
+                td.classes = json_dict["classes"]
+            if json_dict.__contains__("tasks"):
+                td.tasks = [EOTask.from_dict(t) for t in json_dict["tasks"]]
+            if json_dict.__contains__("labeling"):
+                td.labeling = [Labeling.from_dict(labeling) for labeling in json_dict["labeling"]]
+            if json_dict.__contains__("quality"):
+                td.quality = DataQuality.from_dict(json_dict["quality"])
+            if json_dict.__contains__("changesets"):
+                td.changesets = [Changeset.from_dict(changeset) for changeset in json_dict["changesets"]]
+            if json_dict.__contains__("data"):
+                td.data = [EOTrainingData.from_dict(data) for data in json_dict["data"]]
+            if json_dict.__contains__("extent"):
+                td.extent = json_dict["extent"]
+            if json_dict.__contains__("bands"):
+                td.bands = json_dict["bands"]
+            if json_dict.__contains__("imageSize"):
+                td.image_size = json_dict["imageSize"]
+            return td
+        else:
+            raise ValueError("The given json_dict is not a valid EOTrainingDataset")

--- a/pytdml/type/test.py
+++ b/pytdml/type/test.py
@@ -1,0 +1,73 @@
+import jsonschema
+import requests
+
+# Define the URL of the remote JSON schema
+remote_schema_url = "https://raw.githubusercontent.com/opengeospatial/TrainingDML-AI_SWG/main/schemas/1.0/json_schema/ai_pixelLabel.json"
+
+# Load the remote schema from the URL
+response = requests.get(remote_schema_url)
+remote_schema = response.json()
+
+json_data = {
+    "type":"AI_PixelLabel",
+    "imageFormat": ["png"],
+    "imageURL":["this_is_not_a_url.tif"]
+}
+
+# Validate the JSON data against the remote schema
+try:
+    jsonschema.validate(instance=json_data, schema=remote_schema)
+    print("JSON data is valid according to the remote schema.")
+except jsonschema.exceptions.ValidationError as e:
+    print(f"JSON data is not valid: {e}")
+
+# json_data = {
+#     # "confidence":1,
+#     # "isNegative": False,
+#     "type":"AI_ObjectLabel",
+#     "class": "ship",
+#     "object": {
+#     "type": "Feature",
+#     "geometry": {
+#       "type": "Polygon",
+#       "coordinates": [
+#         [
+#           2306.0,
+#           729.0
+#         ],
+#         [
+#           2330.0,
+#           729.0
+#         ],
+#         [
+#           2330.0,
+#           744.0
+#         ],
+#         [
+#           2306.0,
+#           744.0
+#         ],
+#         [
+#           2306.0,
+#           729.0
+#         ]
+#       ]
+#     }
+#     },
+#     "bboxType": "Horizontal BBox",
+# }
+# json_data = {
+#     "type":"AI_SceneLabel",
+#     "class": "industrial",
+# }
+
+# # json_data = {
+# #     "confidence":1,
+# #     "isNegative": True,
+# #     "type":"AI_ObjectLabel",
+# #     "imageFormat": ["png"],
+# #     "imageURL":["this_is_not_a_url.tif"]
+# # }
+
+# # print(SceneLabel.schema_json(indent=2))
+# print(SceneLabel(**json_data).json())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,4 @@ Pillow
 PyYAML
 numpy
 pandas
-opencv-python
-tensorflow
-tensorflow-io
+pydantic

--- a/tests/data/WHU-building.json
+++ b/tests/data/WHU-building.json
@@ -1,0 +1,67 @@
+{
+  "type": "AI_EOTrainingDataset",
+  "id": "whu-building",
+  "name": "WHU-Building Dataset-Building Change Detection Dataset",
+  "description": "This dataset covers an area where a 6.3-magnitude earthquake has occurred in February 2011 and rebuilt in the following years. This dataset consists of aerial images obtained in April 2012 that contains 12796 buildings in 20.5 km2 (16077 buildings in the same area in 2016 dataset).",
+  "license": "CC BY-SA 4.0",
+  "version": "1.0",
+  "amountOfTrainingData": 1,
+  "createdTime": "2011-01-01",
+  "providers": [
+    "Wuhan University"
+  ],
+  "extent": [
+    1560160,
+    5176338.4,
+    1566661.4,
+    5179409.2
+  ],
+  "classes": [
+    {
+      "building": 1
+    }
+  ],
+  "numberOfClasses": 1,
+  "bands": [
+    "red",
+    "green",
+    "blue"
+  ],
+  "imageSize": "32507x15354",
+  "tasks": [
+    {
+      "type": "AI_EOTask",
+      "id": "whu-building-task",
+      "description": "Building change detection based on aerial images",
+      "taskType": "Change Detection"
+    }
+  ],
+  "data": [
+    {
+      "type": "AI_EOTrainingData",
+      "id": "0",
+      "extent": [
+        1560160,
+        5176338.4,
+        1566661.4,
+        5179409.2
+      ],
+      "dataTime": [
+        "2012-01-01",
+        "2016-01-01"
+      ],
+      "dataURL": [
+        "before/before.tif",
+        "after/after.tif"
+      ],
+      "numberOfLabels": 1,
+      "labels": [
+        {
+          "type": "AI_PixelLabel",
+          "imageURL": ["change label/change_label.tif"],
+          "imageFormat": ["TIFF"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_basic_types.py
+++ b/tests/test_basic_types.py
@@ -1,0 +1,138 @@
+import pytest
+from pydantic import ValidationError, BaseModel, validator
+import jsonschema
+import requests
+
+from pytdml.type.basic_types import _validate_date, to_camel,Labeler
+
+base_url = "https://raw.githubusercontent.com/opengeospatial/TrainingDML-AI_SWG/main/schemas/1.0/json_schema/{}.json"
+
+
+class test_date_model(BaseModel):
+    date: str
+
+    @validator("date")
+    def validate_date(cls, v):
+        return _validate_date(v)
+
+
+# Test valid date-time format
+def test_validate_datetime_format():
+    valid_datetime = "2023-10-27T14:30:00"
+    result = _validate_date(valid_datetime)
+    assert result == valid_datetime
+
+
+# Test valid date format
+def test_validate_date_format():
+    valid_date = "2023-10-27"
+    result = _validate_date(valid_date)
+    assert result == valid_date
+
+
+# Test valid time format
+def test_validate_time_format():
+    valid_time = "14:30:00"
+    result = _validate_date(valid_time)
+    assert result == valid_time
+
+
+# Test valid year format
+def test_validate_year_format():
+    valid_year = "2023"
+    result = _validate_date(valid_year)
+    assert result == valid_year
+
+
+# Test valid year-month format
+def test_validate_year_month_format():
+    valid_year_month = "2023-10"
+    result = _validate_date(valid_year_month)
+    assert result == valid_year_month
+
+
+# Test invalid date format
+def test_invalid_format():
+    invalid_date = "2023/10/27"
+    data = {"date": invalid_date}
+    with pytest.raises(
+        ValidationError,
+        match=rf"String {invalid_date} does not match any allowed format",
+    ):
+        test_date_model(**data)
+
+
+# Test invalid date
+def test_invalid_date():
+    invalid_date = "2023-13-35"
+    data = {"date": invalid_date}
+    with pytest.raises(
+        ValidationError,
+        match=rf"String {invalid_date} does not match any allowed format",
+    ):
+        test_date_model(**data)
+
+
+# Test invalid time
+def test_invalid_time():
+    invalid_time = "25:70:70"
+    data = {"date": invalid_time}
+    with pytest.raises(
+        ValidationError,
+        match=rf"String {invalid_time} does not match any allowed format",
+    ):
+        test_date_model(**data)
+
+
+# Test invalid year
+def test_invalid_year():
+    invalid_year = "1800"
+    data = {"date": invalid_year}
+    with pytest.raises(
+        ValidationError,
+        match=rf"String {invalid_year} does not match any allowed format",
+    ):
+        test_date_model(**data)
+
+
+# Test invalid year-month
+def test_invalid_year_month():
+    invalid_year_month = "2023-15"
+    data = {"date": invalid_year_month}
+    with pytest.raises(
+        ValidationError,
+        match=rf"String {invalid_year_month} does not match any allowed format",
+    ):
+        test_date_model(**data)
+
+
+# Test to_camel
+def test_to_camel():
+    camel_string = "thisIsACamelString"
+    snake_string = "this_is_a_camel_string"
+    assert to_camel(snake_string) == camel_string
+
+
+# Test invalid Labeler
+def test_required_elements_with_Labeler():
+    data = {
+        "type": "AI_Labeler",
+        "name": "zhaoyan"
+    }
+    with pytest.raises( ValidationError):
+        Labeler(**data)
+
+# Test valid Labeler and with remote schema
+def test_valid_Labeler_schema():
+    data = {
+        "type": "AI_Labeler",
+        "id": "1",
+        "name": "zhaoyan"
+    }
+    labeler = Labeler(**data)
+
+    remote_schema_url = base_url.format("ai_labeler")
+    response = requests.get(remote_schema_url)
+    remote_schema = response.json()
+
+    jsonschema.validate(instance=labeler.dict(), schema=remote_schema)

--- a/tests/test_tdml_io.py
+++ b/tests/test_tdml_io.py
@@ -1,0 +1,15 @@
+import pytest
+import json
+from pydantic import ValidationError, BaseModel, validator
+
+from pytdml.type.extended_types import EOTrainingDataset
+from pytdml.io.tdml_writers import write_to_json
+from pytdml.io.tdml_readers import read_from_json
+
+
+def test_read_and_write():
+    tdml_path = r"tests/data/WHU-building.json"
+    td = read_from_json(tdml_path)
+    with open(tdml_path, 'r') as f:
+        data = json.load(f)
+    assert td.dict(by_alias=True,exclude_none=True) == data


### PR DESCRIPTION
I have rewritten pytedml/type using pydantic for the purpose of performing format validation according to [TraindingDML-AI JSONSchema](https://gitlab.ogc.org/ogc/TrainingDML-AI/-/tree/master/schemas/1.0/json_schema), and I have added some necessary unit test cases. Currently, it has been tested with the tdml annotation file from WHU-building, and after reading and rewriting it, the output file remains identical to the original one.